### PR TITLE
Data aggregator setup

### DIFF
--- a/sdk/include/opentelemetry/sdk/zpages/tracez_data_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/zpages/tracez_data_aggregator.h
@@ -3,29 +3,39 @@
 //include libraries
 #include <string>
 #include <unordered_set>
+#include <unordered_map>
+#include <vector>
 
 //include files
 #include "opentelemetry/sdk/trace/processor.h"
-
-using namespace opentelemetry::sdk::trace;
+#include "opentelemetry/sdk/trace/span_data.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
 namespace zpages
 {
+
 class TraceZDataAggregator
 {
 public:
-  TraceZDataAggregator(SpanProcessor* traceZSpanProcessor);
+  TraceZDataAggregator(opentelemetry::sdk::trace::SpanProcessor* traceZSpanProcessor);
+  
   std::unordered_set<std::string> getSpanNames();
+  
+  /**This function returns the number of spans with a given name that are currently running,
+  the map maps the name of a span to the number of spans with that name that are running**/ 
+  std::unordered_map<std::string, int> getCountOfRunningSpans();
+  
+  std::vector<opentelemetry::sdk::trace::SpanData> getRunningSpansWithGivenName(std::string spanName);
 
 private:
-  SpanProcessor* spanProcessor;
+  opentelemetry::sdk::trace::SpanProcessor* spanProcessor;
 
 };
-}
-}
+
+} // sdk
+} // zpages
 OPENTELEMETRY_END_NAMESPACE
 
 

--- a/sdk/include/opentelemetry/sdk/zpages/tracez_data_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/zpages/tracez_data_aggregator.h
@@ -1,0 +1,31 @@
+#pragma once
+
+//include libraries
+#include <string>
+#include <unordered_set>
+
+//include files
+#include "opentelemetry/sdk/trace/processor.h"
+
+using namespace opentelemetry::sdk::trace;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace zpages
+{
+class TraceZDataAggregator
+{
+public:
+  TraceZDataAggregator(SpanProcessor* traceZSpanProcessor);
+  std::unordered_set<std::string> getSpanNames();
+
+private:
+  SpanProcessor* spanProcessor;
+
+};
+}
+}
+OPENTELEMETRY_END_NAMESPACE
+
+

--- a/sdk/src/zpages/BUILD
+++ b/sdk/src/zpages/BUILD
@@ -1,0 +1,27 @@
+ 
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "zpages",
+    srcs = glob(["**/*.cc"]),
+    hdrs = glob(["**/*.h"]),
+    include_prefix = "src/zpages",
+    deps = [
+        "//api",
+        "//sdk:headers",
+    ],
+)

--- a/sdk/src/zpages/trace_data_aggregator.cc
+++ b/sdk/src/zpages/trace_data_aggregator.cc
@@ -1,0 +1,23 @@
+#include "opentelemetry/sdk/zpages/tracez_data_aggregator.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace zpages
+{
+
+TraceZDataAggregator::TraceZDataAggregator(SpanProcessor* traceZSpanProcessor)
+{
+  spanProcessor = traceZSpanProcessor;
+}
+
+
+std::unordered_set<std::string> TraceZDataAggregator::getSpanNames()
+{
+  std::unordered_set<std::string> spanNames;
+  return spanNames;
+}
+
+}  // namespace trace
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/zpages/trace_data_aggregator.cc
+++ b/sdk/src/zpages/trace_data_aggregator.cc
@@ -1,12 +1,13 @@
 #include "opentelemetry/sdk/zpages/tracez_data_aggregator.h"
-
+#include<iostream>
 OPENTELEMETRY_BEGIN_NAMESPACE
+
 namespace sdk
 {
 namespace zpages
 {
 
-TraceZDataAggregator::TraceZDataAggregator(SpanProcessor* traceZSpanProcessor)
+TraceZDataAggregator::TraceZDataAggregator(opentelemetry::sdk::trace::SpanProcessor* traceZSpanProcessor)
 {
   spanProcessor = traceZSpanProcessor;
 }
@@ -16,6 +17,19 @@ std::unordered_set<std::string> TraceZDataAggregator::getSpanNames()
 {
   std::unordered_set<std::string> spanNames;
   return spanNames;
+}
+
+
+std::unordered_map<std::string, int> TraceZDataAggregator::getCountOfRunningSpans()
+{
+  std::unordered_map<std::string, int> spanNameToCount;
+  return spanNameToCount;
+}
+  
+std::vector<opentelemetry::sdk::trace::SpanData> TraceZDataAggregator::getRunningSpansWithGivenName(std::string spanName)
+{
+  std::vector<opentelemetry::sdk::trace::SpanData> spansWithSameName;
+  return spansWithSameName;
 }
 
 }  // namespace trace

--- a/sdk/test/zpages/BUILD
+++ b/sdk/test/zpages/BUILD
@@ -1,0 +1,11 @@
+cc_test(
+    name = "tracez_data_aggregator_tests",
+    srcs = [
+        "tracez_data_aggregator_tests.cc",
+    ],
+    deps = [
+        "//sdk/src/trace",
+        "//sdk/src/zpages",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/sdk/test/zpages/tracez_data_aggregator_tests.cc
+++ b/sdk/test/zpages/tracez_data_aggregator_tests.cc
@@ -1,0 +1,20 @@
+#include "opentelemetry/sdk/zpages/tracez_data_aggregator.h"
+#include "opentelemetry/sdk/trace/simple_processor.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/sdk/trace/span_data.h"
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry::sdk::trace;
+using namespace opentelemetry::sdk::zpages;
+
+/**
+ * TODO: Mock traceZ span processor
+ */
+
+TEST(TraceZDataAggregator, GetSpanNamesReturnsEmptySet)
+{
+  TraceZDataAggregator traceZDataAggregator(new SimpleSpanProcessor(nullptr));
+  std::unordered_set<std::string> spanNames = traceZDataAggregator.getSpanNames();
+  ASSERT_TRUE(spanNames.size() == 0);
+}

--- a/sdk/test/zpages/tracez_data_aggregator_tests.cc
+++ b/sdk/test/zpages/tracez_data_aggregator_tests.cc
@@ -12,9 +12,27 @@ using namespace opentelemetry::sdk::zpages;
  * TODO: Mock traceZ span processor
  */
 
-TEST(TraceZDataAggregator, GetSpanNamesReturnsEmptySet)
+TEST(TraceZDataAggregator, getSpanNamesReturnsEmptySet)
 {
   TraceZDataAggregator traceZDataAggregator(new SimpleSpanProcessor(nullptr));
   std::unordered_set<std::string> spanNames = traceZDataAggregator.getSpanNames();
   ASSERT_TRUE(spanNames.size() == 0);
 }
+
+TEST(TraceZDataAggregator, getCountOfRunningSpansReturnsEmptyMap)
+{
+  TraceZDataAggregator traceZDataAggregator(new SimpleSpanProcessor(nullptr));
+  std::unordered_map<std::string, int> spanCount = traceZDataAggregator.getCountOfRunningSpans();
+  ASSERT_TRUE(spanCount.empty());
+}
+
+
+TEST(TraceZDataAggregator, getRunningSpansWithGivenNameReturnsEmptyVector)
+{
+  TraceZDataAggregator traceZDataAggregator(new SimpleSpanProcessor(nullptr));
+  std::vector<SpanData> runningSpans = 
+  traceZDataAggregator.getRunningSpansWithGivenName("Non existing span name");
+  ASSERT_TRUE(runningSpans.empty());
+}
+
+


### PR DESCRIPTION
Basic set up for the tracez data aggregator class. Set up includes the folder structure for the header file, src file and test file along with some initial tests.